### PR TITLE
Don't skip first character on next iteration after recursion

### DIFF
--- a/parser.js
+++ b/parser.js
@@ -9,7 +9,7 @@ module.exports.parse = function parse (program = '') {
 	    const [parsed, rest] = parse(program.substring(i + 1));
 	    tokens.push(parsed);
 	    program = rest;
-	    i = 0;
+	    i = -1;
 	} else if (char === ')') {
 	    tokens.push(+currentToken || currentToken);
 	    return [tokens, program.substring(i + 1)];


### PR DESCRIPTION
Without this change, two adjacent ')' *with code following* (as in `(+ (+ 35 (+ 1 1)) 5)`) would fail.